### PR TITLE
docs: update cli installation command with global flag

### DIFF
--- a/src/cli.md
+++ b/src/cli.md
@@ -13,7 +13,7 @@ In the future, it will allow creating modules/controllers/services.Project creat
 Installing Deno packages as a commands is simple. You can install them under any name you want. For simplicity's sake, we install our danet-cli under the name `danet`.  
 
 ```bash
-$ deno install --allow-read --allow-write --allow-run --allow-env -n danet jsr:@danet/cli
+$ deno install --allow-read --allow-write --allow-run --allow-env --global -n danet jsr:@danet/cli
 ```
 
 ## Basic workflow


### PR DESCRIPTION
When running `deno install --allow-read --allow-write --allow-run --allow-env -n danet jsr:@danet/cli` on `deno 2.2.2`, we get the below error.

```shell
error: the following required arguments were not provided:
  --global

Note: Permission flags can only be used in a global setting
```