### PR TITLE
Fix Danet CLI installation command (add --global)

### DIFF
--- a/src/overview/first-steps.md
+++ b/src/overview/first-steps.md
@@ -14,7 +14,7 @@ v1.24.3) is installed on your operating system.
 The easiest way to set up a Danet project is by using our [Danet CLI](/cli.md)
 
 ```bash
-$ deno install --allow-read --allow-write --allow-run --allow-env -n danet jsr:@danet/cli
+$ deno install --allow-read --allow-write --allow-run --allow-env --global -n danet jsr:@danet/cli
 $ danet new my-danet-project
 $ cd my-danet-project
 ```


### PR DESCRIPTION
Without --global the command fails on deno 2.x (AFAIK)

```sh
$ deno install --allow-read --allow-write --allow-run --allow-env -n danet jsr:@danet/cli
error: the following required arguments were not provided:
  --global

Note: Permission flags can only be used in a global setting
```