### PR TITLE
docs(controllers): document returning files/blobs and response headers

### DIFF
--- a/src/fr/overview/controllers.md
+++ b/src/fr/overview/controllers.md
@@ -71,6 +71,96 @@ export class TodoController {
   }
 }
 ```
+## Objet de réponse
+
+La plupart du temps, il suffit de **retourner une valeur** depuis ton handler et
+de laisser Danet construire la réponse : les objets sont sérialisés en JSON, les
+strings sont envoyées en `text/plain`, et le code de statut vaut `200` par
+défaut.
+
+Lorsque tu as besoin de plus de contrôle — des en-têtes personnalisés, un type
+de contenu spécifique, ou un corps binaire/`Blob` (fichiers, images, PDF...) —
+tu disposes de trois options.
+
+### Retourner une `Response`
+
+Si un handler retourne une
+[`Response`](https://developer.mozilla.org/fr/docs/Web/API/Response) standard,
+Danet l'envoie **telle quelle**, sans aucune sérialisation. C'est la manière la
+plus directe de définir à la fois le corps et les en-têtes, et cela fonctionne
+avec n'importe quelle valeur
+[`BodyInit`](https://developer.mozilla.org/fr/docs/Web/API/Response/Response) :
+un `Blob`, un `ArrayBuffer`, un `Uint8Array`, un `ReadableStream` ou une string.
+
+```ts file.controller.ts
+import { Controller, Get } from 'jsr:@danet/core';
+
+@Controller('files')
+export class FileController {
+  @Get('report')
+  async downloadReport(): Promise<Response> {
+    // `data` peut provenir de Deno.readFile, d'une base de données, d'un fetch distant, etc.
+    const data = await Deno.readFile('./report.pdf');
+    const blob = new Blob([data], { type: 'application/pdf' });
+
+    return new Response(blob, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="report.pdf"',
+      },
+    });
+  }
+}
+```
+
+::: info Astuce
+Comme tu construis toi-même la `Response`, le décorateur `@HttpCode()` est ignoré
+pour ce handler — définis le statut directement sur la `Response`.
+:::
+
+### Définir des en-têtes avec `@Res()`
+
+Si tu préfères continuer à retourner un objet ou une string et que tu as
+seulement besoin d'ajuster les **en-têtes**, injecte l'objet de réponse avec
+`@Res()` et modifie ses `headers`. Danet fusionne ces en-têtes dans la réponse
+qu'il construit à partir de ta valeur de retour.
+
+```ts file.controller.ts
+import { Controller, Get, Res } from 'jsr:@danet/core';
+
+@Controller('files')
+export class FileController {
+  @Get()
+  findAll(@Res() res: Response) {
+    res.headers.set('Cache-Control', 'no-store');
+    res.headers.set('X-Custom-Header', 'danet');
+    return { todos: [] }; // toujours sérialisé en JSON, désormais avec tes en-têtes
+  }
+}
+```
+
+### Utiliser `@Context()`
+
+Pour des cas avancés, tu peux injecter le
+[contexte Hono](https://hono.dev/api/context) sous-jacent avec `@Context()` et
+utiliser ses helpers, comme `c.header()` et `c.body()` :
+
+```ts file.controller.ts
+import { Controller, Get, Context } from 'jsr:@danet/core';
+import type { ExecutionContext } from 'jsr:@danet/core';
+
+@Controller('files')
+export class FileController {
+  @Get('logo')
+  async logo(@Context() ctx: ExecutionContext) {
+    const image = await Deno.readFile('./logo.png');
+    ctx.header('Content-Type', 'image/png');
+    return ctx.body(image);
+  }
+}
+```
+
 ## Ressources
 
 Plus tôt, nous avons défini un endpoint pour récupérer les todos (**GET** route). Nous souhaiterons généralement également fournir un endpoint pour créer de nouveaux todos. Pour cela, créons le handler **POST** :

--- a/src/fr/overview/controllers.md
+++ b/src/fr/overview/controllers.md
@@ -156,7 +156,7 @@ export class FileController {
   async logo(@Context() ctx: ExecutionContext) {
     const image = await Deno.readFile('./logo.png');
     ctx.header('Content-Type', 'image/png');
-    return ctx.body(image);
+    return ctx.body(image.buffer);
   }
 }
 ```

--- a/src/overview/controllers.md
+++ b/src/overview/controllers.md
@@ -97,6 +97,95 @@ objects they represent.
 | `@Query(key: string, options?: { value?: 'first' \| 'last' \| 'array' })` | `string \| string[]`                              | Get the `first`, the `last` or `all` the values for the query parameter named `key` |
 | `@Query(options?: { value?: 'first' \| 'last' \| 'array' })`              | `{ [key: string]: string \| string[] }`           | Get the `first`, the `last` or `all` the values for all the query parameters        |
 
+## Response object
+
+Most of the time you can simply **return a value** from your handler and let
+Danet build the response for you: objects are serialized to JSON, strings are
+sent as `text/plain`, and the status code defaults to `200` (see
+[Status code](#status-code)).
+
+When you need more control — custom headers, a specific content type, or a
+binary/`Blob` body (files, images, PDFs...) — you have three options.
+
+### Returning a `Response`
+
+If a handler returns a standard
+[`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response), Danet
+sends it **as-is**, without any serialization. This is the most direct way to
+set both the body and the headers, and it works with any
+[`BodyInit`](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response)
+value — a `Blob`, an `ArrayBuffer`, a `Uint8Array`, a `ReadableStream`, or a
+string.
+
+```ts file.controller.ts
+import { Controller, Get } from 'jsr:@danet/core';
+
+@Controller('files')
+export class FileController {
+  @Get('report')
+  async downloadReport(): Promise<Response> {
+    // `data` could come from Deno.readFile, a database, a remote fetch, etc.
+    const data = await Deno.readFile('./report.pdf');
+    const blob = new Blob([data], { type: 'application/pdf' });
+
+    return new Response(blob, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="report.pdf"',
+      },
+    });
+  }
+}
+```
+
+::: info Hint
+Because you build the `Response` yourself, the `@HttpCode()` decorator is
+ignored for that handler — set the status directly on the `Response`.
+:::
+
+### Setting headers with `@Res()`
+
+If you'd rather keep returning a plain object or string and only need to tweak
+the **headers**, inject the response object with `@Res()` and mutate its
+`headers`. Danet merges those headers into the response it builds from your
+return value.
+
+```ts file.controller.ts
+import { Controller, Get, Res } from 'jsr:@danet/core';
+
+@Controller('files')
+export class FileController {
+  @Get()
+  findAll(@Res() res: Response) {
+    res.headers.set('Cache-Control', 'no-store');
+    res.headers.set('X-Custom-Header', 'danet');
+    return { todos: [] }; // still serialized to JSON, now with your headers
+  }
+}
+```
+
+### Using `@Context()`
+
+For advanced cases you can inject the underlying
+[Hono context](https://hono.dev/api/context) with `@Context()` and use its
+helpers, such as `c.header()` and `c.body()`:
+
+```ts file.controller.ts
+import { Controller, Get, Context } from 'jsr:@danet/core';
+import type { ExecutionContext } from 'jsr:@danet/core';
+
+@Controller('files')
+export class FileController {
+  @Get('logo')
+  async logo(@Context() ctx: ExecutionContext) {
+    const image = await Deno.readFile('./logo.png');
+    ctx.header('Content-Type', 'image/png');
+    return ctx.body(image);
+  }
+}
+```
+
 ## Resources
 
 Earlier, we defined an endpoint to fetch the todo resource (**GET** route).

--- a/src/overview/controllers.md
+++ b/src/overview/controllers.md
@@ -181,7 +181,7 @@ export class FileController {
   async logo(@Context() ctx: ExecutionContext) {
     const image = await Deno.readFile('./logo.png');
     ctx.header('Content-Type', 'image/png');
-    return ctx.body(image);
+    return ctx.body(image.buffer);
   }
 }
 ```


### PR DESCRIPTION
Answers [discussion #121](https://github.com/Savory/Danet/discussions/121): *"How can I set the headers of the response and the body as a blob?"*

Adds a **"Response object"** section to the Controllers page (EN + FR) covering three approaches:

1. **Return a `Response`** — sent as-is, works with any `BodyInit` (`Blob`, `ArrayBuffer`, `Uint8Array`, `ReadableStream`, string). The direct answer for a blob body with custom headers.
2. **`@Res()`** — set headers while still returning a serialized value.
3. **`@Context()`** — use Hono helpers (`c.header()`, `c.body()`) for advanced cases.

The behaviors are covered by tests in a companion PR on `Savory/Danet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnF4fzmM7CwBfq7zXBnQsF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Response object” section to the controller guide.
  * Clarified how handler return values are turned into HTTP responses by default.
  * Added examples for returning a native response directly, updating headers while still serializing data, and accessing the request context for response helpers.
  * Included a note that HTTP status decorators are ignored when a handler returns a native response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->